### PR TITLE
Properly convert this to 1.13

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+version: '{build}'
+skip_tags: true
+clone_depth: 10
+environment:
+  matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+branches:
+  only:
+    - master
+  except:
+    - gh-pages
+os: Windows Server 2012
+install:
+  - ps: |
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
+      if (!(Test-Path -Path "C:\maven" )) {
+        (new-object System.Net.WebClient).DownloadFile('http://www.us.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip', 'C:\maven-bin.zip')
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
+      }
+  - cmd: SET PATH=C:\maven\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
+  - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
+  - cmd: mvn --version
+  - cmd: java -version
+build_script:
+  - mvn clean package -B -Dmaven.test.skip=true
+test_script:
+  - mvn clean install --batch-mode -Pqulice
+cache:
+  - C:\maven\
+  - C:\Users\appveyor\.m2
+artifacts:
+- path: target/GraviTree.jar
+  name: GraviTree

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.ryanhamshire</groupId>
     <artifactId>GraviTree</artifactId>
-    <version>2.8.1</version>
+    <version>2.8.2</version>
     <packaging>jar</packaging>
     <name>GraviTree</name>
     <description>No more floating treetops.</description>
@@ -14,12 +14,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.13.1-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
@@ -85,6 +79,7 @@
                             <shadedPattern>me.ryanhamshire.GraviTree</shadedPattern>
                         </relocation>
                     </relocations>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/me/ryanhamshire/GraviTree/ExtraTags.java
+++ b/src/main/java/me/ryanhamshire/GraviTree/ExtraTags.java
@@ -1,0 +1,39 @@
+package me.ryanhamshire.GraviTree;
+
+import org.bukkit.Bukkit;
+import org.bukkit.DyeColor;
+import org.bukkit.Material;
+import org.bukkit.Tag;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Created on 10/5/2018.
+ *
+ * @author RoboMWM
+ */
+public enum ExtraTags
+{
+    TERRACOTTA;
+
+    ExtraTags()
+    {
+        for (Material material : Material.values())
+        {
+            if (material.name().equals(this.name()))
+                materials.add(material);
+            else for (DyeColor color : DyeColor.values())
+                if (material.name().equals(color.name() + "_" + this.name()))
+                    materials.add(material);
+        }
+    }
+
+    private Set<Material> materials = new HashSet<>();
+
+    public boolean isTagged(Material material)
+    {
+        return materials.contains(material);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,8 @@
 name: GraviTree
 main: me.ryanhamshire.GraviTree.GraviTree
-version: 2.8.1
+version: 2.8.2
+authors: ['Big_Scary', 'RoboMWM']
+version: ${project.version}
 api-version: 1.13
 commands:
    treesfall:


### PR DESCRIPTION
I've seen a couple people do it, but they all screwed up in one way or another. Excluding things such as not using the included Tags, listed below are the ways they screwed up:
- Including only one variant of Terracotta
- Erraneously including clay (the clay block)
- Erraneously using ACACIA_LOG/including other types of logs when the original code was only looking for DARK_OAK logs (log_2 with data value 1)
- Continuing to use deprecated methods (getData, spawnFallingBlock)