### PR TITLE
Allow block dropping

### DIFF
--- a/src/main/java/me/ryanhamshire/GraviTree/GraviTree.java
+++ b/src/main/java/me/ryanhamshire/GraviTree/GraviTree.java
@@ -409,7 +409,7 @@ public class GraviTree extends JavaPlugin implements Listener
             if(GraviTree.blockIsLog(this.blockToDrop))
             {
                 FallingBlock fallingBlock = blockToDrop.getWorld().spawnFallingBlock(blockToDrop.getLocation().add(.5, 0, .5), blockToDrop.getBlockData());
-                fallingBlock.setDropItem(false);
+                fallingBlock.setDropItem(true);
 
                 blockToDrop.setType(Material.AIR);
                 


### PR DESCRIPTION
When using this plugin, I noticed that, as a falling block, the blocks don't drop. This is annoying as when I have placed torches, blocks fall on them and disappear. A player could lose logs, and not even notice! I think that this will only make a little bit of difference, but for me at least, I could use those extra logs that could get lost without noticing. After looking through the code, I found the statement on line 412 that was the culprit, so I've changed it to true to solve the problems.